### PR TITLE
Fix clearadi stub

### DIFF
--- a/clearadi/src/lib.rs
+++ b/clearadi/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, ffi, fmt::Display, ptr::null_mut, slice};
+use std::{error::Error, ffi, fmt::Display};
 
 use serde::{Deserialize, Serialize};
 
@@ -11,10 +11,17 @@ impl Display for ClearAdiError {
     }
 }
 
+#[derive(Serialize, Deserialize, Clone)]
+pub enum AnisetteFlavor {
+    Mac,
+    IOS
+}
+
 pub struct ProvisionedMachine {
     pub client_secret: [u8; 32],
     pub mid: [u8; 60],
     pub metadata: Vec<u8>,
+    pub flavor: AnisetteFlavor,
 }
 
 impl ProvisionedMachine {
@@ -41,11 +48,11 @@ pub struct ProvisioningSession(*mut ffi::c_void);
 unsafe impl Send for ProvisioningSession { }
 
 impl ProvisioningSession {
-    pub fn new(spim: &[u8], _hostuuid: &[u8], _dsid: i64) -> Result<(Self, Vec<u8>), ClearAdiError> {
+    pub fn new(_spim: &[u8], _hostuuid: &[u8], _dsid: i64, _flavor: AnisetteFlavor) -> Result<(Self, Vec<u8>), ClearAdiError> {
         todo!()
     }
 
-    pub fn finish(self, tk: &[u8], ptm: &[u8]) -> Result<ProvisionedMachine, ClearAdiError> {
+    pub fn finish(self, _tk: &[u8], _ptm: &[u8]) -> Result<ProvisionedMachine, ClearAdiError> {
         todo!()
     }
 }

--- a/omnisette/Cargo.toml
+++ b/omnisette/Cargo.toml
@@ -29,7 +29,7 @@ futures-util = { version = "0.3.28", optional = true }
 chrono = { version = "0.4.37" }
 thiserror = "1.0.58"
 anyhow = "1.0.81"
-clearadi = { path = "/home/tae/Documents/clearadi", optional = true }
+clearadi = { path = "../clearadi", optional = true }
 tokio = "1"
 
 [target.'cfg(target_os = "macos")'.dependencies]


### PR DESCRIPTION
Updates clearadi stub API and updates dep path in cargo.toml to default to the stub instead of the real implementation to make it buildable again

Edit: please also update the git submodule in rustpush, thanks 🙏🏼 