### PR TITLE
Use HTTPS for the clearadi submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "clearadi"]
 	path = clearadi
-	url = git@github.com:OpenBubbles/clearadi-stub.git
+	url = https://github.com/OpenBubbles/clearadi-stub.git


### PR DESCRIPTION
The `clearadi` submodule is declared with an SSH URL
(`git@github.com:OpenBubbles/clearadi-stub.git`). That breaks
`cargo build` for any downstream crate that depends on this repo
transitively, because Cargo's URL parser rejects the SSH form before
any fetch is attempted — and importantly, even setting
`net.git-fetch-with-cli = true` doesn't help, because URL parsing
happens before the fetch is delegated to system git.

Concrete failure mode (reproduced against current `master` via
`thisiscam/rustpush` → `OpenBubbles/apple-private-apis`):

```
$ cargo build --release
error: failed to update submodule `apple-private-apis`

Caused by:
  failed to update submodule `clearadi`

Caused by:
  invalid url `git@github.com:OpenBubbles/clearadi-stub.git`:
  relative URL without a base; try using
  `ssh://git@github.com/OpenBubbles/clearadi-stub.git` instead
```

Since `clearadi-stub` is a public read-only repository, an HTTPS URL
is functionally equivalent for everyone and removes this friction
entirely. Anyone who prefers SSH for git operations can override
locally without affecting downstream crates:

```
git config url."git@github.com:".insteadOf "https://github.com/"
```

## How was this tested

Cloned this repo recursively via system git after applying the change
— `clearadi-stub` checks out cleanly without any authentication step.
Then built a downstream crate (`thisiscam/export-findmy` →
`thisiscam/rustpush`) against this commit and confirmed `cargo build`
no longer errors on the submodule URL.